### PR TITLE
fix: Update to current OpenAI model `gpt-3.5-turbo-instruct`

### DIFF
--- a/cloudflare-openai-boilerplate/README.md
+++ b/cloudflare-openai-boilerplate/README.md
@@ -151,7 +151,7 @@ You can deploy the static frontend (the contents of `frontend/frontend-app/dist`
 
 ## Customization
 
-*   **OpenAI Model:** Change the `model` parameter in `backend/worker-backend/src/index.js` to use different OpenAI models (e.g., `gpt-3.5-turbo` for chat completions, which would require changing the API endpoint and request/response structure).
+*   **OpenAI Model:** The default model is `gpt-3.5-turbo-instruct`. You can change the `model` parameter in `backend/worker-backend/src/index.js` to use different OpenAI models (e.g., other models compatible with the `/v1/completions` endpoint, or switch to `/v1/chat/completions` for models like `gpt-4` which would require changing the API endpoint and request/response structure).
 *   **Frontend UI:** Modify the React components in `frontend/frontend-app/src/` to change the appearance and functionality.
 *   **Worker Logic:** Extend the Cloudflare Worker in `backend/worker-backend/src/index.js` for more complex backend tasks.
 ```

--- a/cloudflare-openai-boilerplate/backend/worker-backend/src/index.js
+++ b/cloudflare-openai-boilerplate/backend/worker-backend/src/index.js
@@ -36,7 +36,7 @@ export default {
           'Authorization': `Bearer ${env.OPENAI_API_KEY}`,
         },
         body: JSON.stringify({
-          model: 'text-davinci-003', // You can change the model as needed
+          model: 'gpt-3.5-turbo-instruct', // You can change the model as needed
           prompt: prompt,
           max_tokens: 150,
         }),


### PR DESCRIPTION
This commit addresses the "model_not_found" error from the OpenAI API by updating the model used.

Changes:
- In `backend/worker-backend/src/index.js`:
  - Changed the `model` in the OpenAI API call from the deprecated `text-davinci-003` to `gpt-3.5-turbo-instruct`.
- In `README.md`:
  - Updated the "Customization" section to reflect that `gpt-3.5-turbo-instruct` is now the default model.

This change ensures the application uses a valid and current OpenAI model for text completions via the `/v1/completions` endpoint.