### PR TITLE
Fix: Allow PUT and DELETE requests for budget plans

### DIFF
--- a/cloudflare-openai-boilerplate/backend/worker-backend/src/index.js
+++ b/cloudflare-openai-boilerplate/backend/worker-backend/src/index.js
@@ -6,7 +6,7 @@ const corsHeaders = {
   // IMPORTANT FOR PRODUCTION: Replace 'YOUR_FRONTEND_DOMAIN_HERE' with your actual frontend application's domain.
   // For local development, '*' can be used, but it's insecure for production.
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS', // Added GET
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS', // Added GET
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 };
 
@@ -19,7 +19,7 @@ function handleOptions(request) {
   ) {
     return new Response(null, { headers: corsHeaders });
   } else {
-    return new Response(null, { headers: { Allow: 'GET, POST, OPTIONS' } }); // Added GET
+    return new Response(null, { headers: { Allow: 'GET, POST, PUT, DELETE, OPTIONS' } }); // Added GET
   }
 }
 


### PR DESCRIPTION
The Budgeting Planner Page was unable to edit and delete entries because the backend CORS policy did not allow PUT and DELETE HTTP methods.

This commit updates the 'Access-Control-Allow-Methods' header to include 'PUT' and 'DELETE', enabling these operations for budget plans. The 'Allow' header in the OPTIONS request handler has also been updated accordingly.