### PR TITLE
feat: Enable horizontal scrolling for charts

### DIFF
--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/components/CryptoDisplay.jsx
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/components/CryptoDisplay.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getCoinMarketChart } from '../services/cryptoService.js'; // Adjusted path
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 
 const CryptoDisplay = () => {
   const [selectedCoin, setSelectedCoin] = useState('bitcoin');
@@ -253,9 +253,13 @@ const CryptoDisplay = () => {
             {isCoinChartLoading && <p>Loading chart data...</p>}
             {coinChartError && <p style={{ color: 'red' }}>Error: {coinChartError}</p>}
             {!isCoinChartLoading && !coinChartError && coinChartData && coinChartData.length > 0 && (
-              <div style={{ width: '100%', height: 350, marginTop: '10px' }}>
-                <ResponsiveContainer>
-                  <LineChart data={coinChartData} margin={{ top: 5, right: 25, left: 25, bottom: 5 }}>
+              <div style={{ width: '100%', height: 350, marginTop: '10px', overflowX: 'auto' }}> {/* Added overflowX */}
+                  <LineChart
+                    width={1200} // Added fixed width
+                    height={350} // Ensured height is set
+                    data={coinChartData}
+                    margin={{ top: 5, right: 25, left: 25, bottom: 5 }}
+                  >
                     <CartesianGrid strokeDasharray="3 3" stroke="#ccc"/>
                     <XAxis dataKey="date" stroke="#333" />
                     <YAxis
@@ -279,7 +283,6 @@ const CryptoDisplay = () => {
                         activeDot={{ r: 6, stroke: '#0056b3', fill: '#007bff' }}
                     />
                   </LineChart>
-                </ResponsiveContainer>
               </div>
             )}
             {!isCoinChartLoading && !coinChartError && (!coinChartData || coinChartData.length === 0) && selectedCoin && (

--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/components/StockHistoricalChart.jsx
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/components/StockHistoricalChart.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 
 const StockHistoricalChart = ({ historicalData, stockName }) => {
   if (!historicalData || historicalData.length === 0) {
@@ -16,23 +16,27 @@ const StockHistoricalChart = ({ historicalData, stockName }) => {
       padding: '20px',
       borderRadius: '5px',
       marginTop: '20px',
-      backgroundColor: '#f9f9f9' // Light background for the chart area
+      backgroundColor: '#f9f9f9', // Light background for the chart area
+      overflowX: 'auto' // Added this
     }}>
       <h4 style={{ textAlign: 'center', marginBottom: '20px' }}>
         Historical Closing Prices for {stockName || 'Selected Stock'}
       </h4>
-      <ResponsiveContainer width="100%" height={400}>
-        <LineChart
-          data={sortedData}
-          margin={{
-            top: 5,
-            right: 30, // Increased right margin for YAxis labels if they were on the right
-            left: 20,  // Increased left margin for YAxis labels
-            bottom: 5,
-          }}
-        >
-          <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
-          <XAxis
+      {/* ResponsiveContainer might be removed or adjusted. For fixed width chart,
+          LineChart itself gets the width/height directly. */}
+      <LineChart
+        width={1200} // Example fixed width
+        height={400}
+        data={sortedData}
+        margin={{
+          top: 5,
+          right: 30,
+          left: 20,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke="#ccc" />
+        <XAxis
             dataKey="date"
             stroke="#333"
             // Optional: tickFormatter to shorten date if necessary
@@ -60,7 +64,6 @@ const StockHistoricalChart = ({ historicalData, stockName }) => {
             dot={false} // Hides dots on the line for a cleaner look, activeDot shows on hover
           />
         </LineChart>
-      </ResponsiveContainer>
     </div>
   );
 };


### PR DESCRIPTION
Implemented horizontal scrolling for detailed data viewing in charts on the dashboard, based on your feedback.

Changes:
- Modified `StockHistoricalChart.jsx`:
    - Removed `ResponsiveContainer`.
    - Set a fixed width (1200px) and height for the `LineChart`.
    - Added `overflow-x: auto` to the chart's wrapping div to enable horizontal scrolling.
- Modified `CryptoDisplay.jsx`:
    - Applied the same changes to its `LineChart` as done for `StockHistoricalChart.jsx` (fixed width, height, scrolling wrapper).
- Reviewed `BlockchainDataViewer.jsx` and confirmed its existing table scrolling mechanism is adequate.

This allows you to scroll horizontally within chart components if the data displayed is wider than the viewport, providing a way to inspect detailed chart information.