### PR TITLE
fix: Correct SettingsContext export and update imports

### DIFF
--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/App.jsx
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/App.jsx
@@ -1,7 +1,7 @@
 // frontend/frontend-app/src/App.jsx
 import React, { useState, useContext } from 'react'; // Import useContext
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import SettingsContext from './contexts/SettingsContext.js'; // Import SettingsContext
+import { SettingsContext } from './contexts/SettingsContext.js'; // Import SettingsContext
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import SplashScreen from './pages/SplashScreen';

--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/contexts/SettingsContext.js
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/contexts/SettingsContext.js
@@ -49,4 +49,4 @@ export const SettingsProvider = ({ children }) => {
 };
 
 // Export SettingsContext
-export default SettingsContext;
+export { SettingsContext };

--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/pages/DashboardPage.jsx
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/pages/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react'; // Added useState for WalletAnalyzer, useEffect for stock data, useContext for settings
-import SettingsContext from '../contexts/SettingsContext.js'; // Import SettingsContext
+import { SettingsContext } from '../contexts/SettingsContext.js'; // Import SettingsContext
 import CryptoDisplay from '../components/CryptoDisplay'; // Import CryptoDisplay
 import StockSelector from '../components/StockSelector';
 import StockQuoteDisplay from '../components/StockQuoteDisplay';

--- a/cloudflare-openai-boilerplate/frontend/frontend-app/src/pages/SettingsPage.jsx
+++ b/cloudflare-openai-boilerplate/frontend/frontend-app/src/pages/SettingsPage.jsx
@@ -1,6 +1,6 @@
 // frontend/frontend-app/src/pages/SettingsPage.jsx
 import React, { useContext } from 'react';
-import SettingsContext from '../contexts/SettingsContext.js'; // Adjusted path
+import { SettingsContext } from '../contexts/SettingsContext.js'; // Adjusted path
 // Removed NavigationBar import
 
 function SettingsPage() { // Removed handleLogout from props


### PR DESCRIPTION
Changed SettingsContext to be a named export instead of a default export in `contexts/SettingsContext.js`.

Updated import statements in `SettingsPage.jsx`, `DashboardPage.jsx`, and `App.jsx` to correctly import SettingsContext as a named import.

This resolves a JS syntax issue identified by Vite's import analysis and ensures consistency in how the context and its provider are exported and imported.